### PR TITLE
Fix CI pipeline: add missing deps, postgres service, env vars, and CLAUDE.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,20 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: ci
+          POSTGRES_PASSWORD: ci
+          POSTGRES_DB: stake_n_shares_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,7 +43,9 @@ jobs:
           ALPACA_BASE_URL="${ALPACA_BASE_URL:-https://paper-api.alpaca.markets}"
           echo "ALPACA_API_KEY=$ALPACA_API_KEY" >> $GITHUB_ENV
           echo "ALPACA_SECRET_KEY=$ALPACA_SECRET_KEY" >> $GITHUB_ENV
+          echo "ALPACA_API_SECRET=$ALPACA_SECRET_KEY" >> $GITHUB_ENV
           echo "ALPACA_BASE_URL=$ALPACA_BASE_URL" >> $GITHUB_ENV
+          echo "DATABASE_URL=postgresql://ci:ci@localhost:5432/stake_n_shares_test" >> $GITHUB_ENV
 
       - name: Install dependencies
         run: |
@@ -47,7 +63,7 @@ jobs:
       - name: Run tests with coverage
         run: |
           . .venv/bin/activate
-          pytest -q --cov=paper_trading --cov-report=term --cov-report=xml --cov-report=html
+          pytest -q --cov=paper_trading --cov=backend --cov-report=term --cov-report=xml --cov-report=html -m "not integration"
 
       - name: Upload coverage HTML artifact
         uses: actions/upload-artifact@v4
@@ -61,3 +77,26 @@ jobs:
       #   with:
       #     token: ${{ secrets.CODECOV_TOKEN }}
       #     files: ./coverage.xml
+
+  frontend-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build
+        run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ htmlcov/
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
+*.db
 
 # Flask stuff:
 instance/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md — Stake N' Shares
+
+## Project Overview
+
+Stake N' Shares is a full-stack investment and sports-betting analytics dashboard. Users compare equity returns (via Alpaca) against betting outcomes (via The Odds API) over a date range, seeing combined ROI, PnL, and performance metrics.
+
+## Architecture
+
+- **Backend**: Python 3.11, FastAPI, SQLAlchemy, PostgreSQL
+  - `backend/app/` — FastAPI application (routes, services, schemas, models, config)
+  - `paper_trading/` — Alpaca paper-trading SDK wrapper (account, orders, positions)
+- **Frontend**: React 18, TypeScript, Vite, Chakra UI
+  - `frontend/src/` — React SPA with compare form, result display, and comparison history
+- **Database**: PostgreSQL 16 (local via docker-compose on port 5433)
+
+## Development Setup
+
+```bash
+# 1. Python venv
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+
+# 2. Start PostgreSQL
+docker-compose up -d
+
+# 3. Configure environment
+cp .env.example .env   # then fill in your API keys
+
+# 4. Run dev servers (backend + frontend concurrently)
+npm run dev
+# Or backend only:
+uvicorn backend.app.main:app --reload --port 8000
+```
+
+## Running Tests
+
+### Backend (from repo root)
+```bash
+pytest -q                                      # all tests
+pytest -q -m "not integration"                 # skip integration tests (no real API keys needed)
+pytest -q --cov=paper_trading --cov=backend    # with coverage
+```
+
+### Frontend
+```bash
+cd frontend && npm test
+```
+
+## Environment Variables
+
+| Variable | Used By | Description |
+|---|---|---|
+| `ALPACA_API_KEY` | backend, paper_trading | Alpaca API key |
+| `ALPACA_API_SECRET` | backend | Alpaca API secret (backend uses this name) |
+| `ALPACA_SECRET_KEY` | paper_trading | Alpaca API secret (paper_trading accepts this or `ALPACA_API_SECRET`) |
+| `ALPACA_BASE_URL` | backend, paper_trading | Alpaca base URL |
+| `DATABASE_URL` | backend | PostgreSQL connection string |
+| `ODDS_API_KEY` | backend | The Odds API key |
+| `USE_EXTERNAL_APIS` | backend | `true` to hit real APIs; `false` for stub/fallback mode |
+
+## CI/CD
+
+GitHub Actions workflow at `.github/workflows/ci.yml`:
+- **test** job: Python 3.11, PostgreSQL 16 service, runs pytest with coverage on `paper_trading` and `backend`
+- **frontend-test** job: Node 20, runs vitest and Vite build
+
+Integration tests (marked `@pytest.mark.integration`) are skipped in CI.
+
+## Key Conventions
+
+- Two separate Pydantic Settings classes: `backend/app/config.py` (API keys) and `backend/app/core/settings.py` (DATABASE_URL).
+- Tests in `tests/` cover the `paper_trading` module; tests in `backend/tests/` cover the FastAPI backend.
+- `backend/tests/conftest.py` auto-disables external APIs via monkeypatch for deterministic unit tests.
+- Frontend tests use vitest + React Testing Library + jsdom.
+
+## Update Policy
+
+Update this file after every commit that changes project structure, dependencies, test configuration, or CI/CD setup.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 pythonpath = .
-testpaths = tests
+testpaths = tests backend/tests
 markers =
     integration: tests that hit real external APIs
 addopts = --strict-markers

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,6 @@ websockets==15.0.1
 alpaca-py
 pytest-cov
 codecov
+pydantic-settings
+SQLAlchemy
+psycopg2-binary


### PR DESCRIPTION
## Summary

- **Fixed 6 root causes** that have been breaking the CI pipeline for months:
  - Added missing Python dependencies (`pydantic-settings`, `SQLAlchemy`, `psycopg2-binary`) to `requirements.txt` — backend imports were failing at test collection time
  - Expanded `pytest.ini` testpaths from `tests` to `tests backend/tests` — 14 of 17 tests were never being discovered
  - Added PostgreSQL 16 service container to CI workflow — backend requires `DATABASE_URL` at import time
  - Added `ALPACA_API_SECRET` env var to CI — `main.py` validates this name but CI only set `ALPACA_SECRET_KEY`
  - Added `--cov=backend` to pytest command — coverage was only tracking `paper_trading`
  - Added `-m "not integration"` flag — integration tests requiring real API keys were running and failing
- **Added frontend-test job** (Node 20, vitest, Vite build)
- **Created `CLAUDE.md`** with project conventions, dev setup, test commands, and update-after-every-commit policy
- Added `*.db` to `.gitignore` to prevent test SQLite artifacts from being tracked

## Test plan

- [x] Verified `pip install -r requirements.txt` succeeds with new dependencies
- [x] Verified `pytest --collect-only` discovers all 20 tests across both directories
- [x] Verified `pytest -q -m "not integration"` passes all 17 non-integration tests locally
- [ ] Verify GitHub Actions workflow passes on this branch

<https://claude.ai/code/session_01GKiZmd2c1QKnmFhWpruAuD>